### PR TITLE
[SE-27] Маркдаун линтер триггерится на ветку

### DIFF
--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -7,14 +7,14 @@ on:
     paths:
       - ".github/workflows/*"
       - ".markdownlint.yaml"
-      - "**/*.md"
+      - "*.md"
   pull_request:
     branches:
       - main
     paths:
       - ".github/workflows/*"
       - ".markdownlint.yaml"
-      - "**/*.md"
+      - "*.md"
 
 jobs:
   lint:
@@ -27,6 +27,6 @@ jobs:
       - name: markdownlint-cli
         uses: nosborn/github-action-markdown-cli@v3.3.0
         with:
-          files: "**/*.md"
+          files: "*.md"
           config_file: .markdownlint.yaml
           dot: true


### PR DESCRIPTION
Теперь линтер не триггерится на вложенные .md файлы (в том числе файл ветки с README.md в названии)